### PR TITLE
spdk_zmalloc: Remove unnecessary memset()

### DIFF
--- a/lib/env_dpdk/env.c
+++ b/lib/env_dpdk/env.c
@@ -71,7 +71,7 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr, int socket_id, uint3
 	buf = rte_malloc_socket(NULL, size, align, socket_id);
 	if (buf && phys_addr) {
 #ifdef DEBUG
-		SPDK_ERRLOG("phys_addr param in spdk_*malloc() is deprecated\n");
+		SPDK_ERRLOG("phys_addr param in spdk_malloc() is deprecated\n");
 #endif
 		*phys_addr = virt_to_phys(buf);
 	}
@@ -81,9 +81,19 @@ spdk_malloc(size_t size, size_t align, uint64_t *phys_addr, int socket_id, uint3
 void *
 spdk_zmalloc(size_t size, size_t align, uint64_t *phys_addr, int socket_id, uint32_t flags)
 {
-	void *buf = spdk_malloc(size, align, phys_addr, socket_id, flags);
-	if (buf) {
-		memset(buf, 0, size);
+	void *buf;
+
+	if (flags == 0) {
+		return NULL;
+	}
+
+	align = spdk_max(align, RTE_CACHE_LINE_SIZE);
+	buf = rte_zmalloc_socket(NULL, size, align, socket_id);
+	if (buf && phys_addr) {
+#ifdef DEBUG
+		SPDK_ERRLOG("phys_addr param in spdk_zmalloc() is deprecated\n");
+#endif
+		*phys_addr = virt_to_phys(buf);
 	}
 	return buf;
 }


### PR DESCRIPTION
Normally, unless RTE_MALLOC_DEBUG is set, DPDK zeroes memory in rte_free().
If RTE_MALLOC_DEBUG rte_free() fills memory with poison pattern, but then
(and only then) the memory is zeroed in rte_zmalloc_socket(). Relying on
this behavior allows to avoid unnecessary memset() in spdk_zmalloc() path.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>
Change-Id: If3efa4dd22f1568949c3fb529b604bd597ceb32f
Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>
Reviewed-on: https://review.spdk.io/gerrit/c/spdk/spdk/+/6975
Community-CI: Broadcom CI
Community-CI: Mellanox Build Bot
Tested-by: SPDK CI Jenkins <sys_sgci@intel.com>
Reviewed-by: Ben Walker <benjamin.walker@intel.com>
Reviewed-by: Jim Harris <james.r.harris@intel.com>
Reviewed-by: Aleksey Marchuk <alexeymar@mellanox.com>
Reviewed-by: Shuhei Matsumoto <shuhei.matsumoto.xt@hitachi.com>
Reviewed-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>