### PR TITLE
[experimental] Set sequential cutoff

### DIFF
--- a/module/bdev/ocf/utils.c
+++ b/module/bdev/ocf/utils.c
@@ -75,6 +75,24 @@ ocf_get_cache_line_size(ocf_cache_t cache)
 	return ocf_cache_get_line_size(cache) / KiB;
 }
 
+static char *seqcutoff_policies[ocf_seq_cutoff_policy_max] = {
+	[ocf_seq_cutoff_policy_always] = "always",
+	[ocf_seq_cutoff_policy_full] = "full",
+	[ocf_seq_cutoff_policy_never] = "never",
+};
+
+ocf_seq_cutoff_policy
+ocf_get_seqcutoff_policy(const char *policy_name)
+{
+	int i;
+
+	for (i = 0; i < ocf_seq_cutoff_policy_max; i++)
+		if (!strcmp(policy_name, seqcutoff_policies[i]))
+			return i;
+
+	return ocf_seq_cutoff_policy_default;
+}
+
 int
 vbdev_ocf_mngt_start(struct vbdev_ocf *vbdev, vbdev_ocf_mngt_fn *path,
 		     vbdev_ocf_mngt_callback cb, void *cb_arg)

--- a/module/bdev/ocf/utils.h
+++ b/module/bdev/ocf/utils.h
@@ -43,6 +43,9 @@ const char *ocf_get_cache_modename(ocf_cache_mode_t mode);
 /* Get cache line size in KiB units */
 int ocf_get_cache_line_size(ocf_cache_t cache);
 
+/* Get sequential cutoff policy by name */
+ocf_seq_cutoff_policy ocf_get_seqcutoff_policy(const char *policy_name);
+
 /* Initiate management operation
  * Receives NULL terminated array of functions (path)
  * and callback (cb)

--- a/module/bdev/ocf/vbdev_ocf.h
+++ b/module/bdev/ocf/vbdev_ocf.h
@@ -215,6 +215,15 @@ void vbdev_ocf_set_cache_mode(
 	void (*cb)(int, struct vbdev_ocf *, void *),
 	void *cb_arg);
 
+/* Set sequential cutoff parameters on OCF cache */
+void vbdev_ocf_set_seqcutoff(
+	struct vbdev_ocf *vbdev,
+	const char *policy_name,
+	int32_t threshold,
+	int32_t promotion_count,
+	void (*cb)(int, void *),
+	void *cb_arg);
+
 typedef void (*vbdev_ocf_foreach_fn)(struct vbdev_ocf *, void *);
 
 /* Execute fn for each OCF device that is online or waits for base devices */

--- a/module/bdev/ocf/vbdev_ocf_rpc.c
+++ b/module/bdev/ocf/vbdev_ocf_rpc.c
@@ -442,3 +442,74 @@ end:
 	free_rpc_bdev_ocf_set_cache_mode(&req);
 }
 SPDK_RPC_REGISTER("bdev_ocf_set_cache_mode", rpc_bdev_ocf_set_cache_mode, SPDK_RPC_RUNTIME)
+
+static void
+seqcutoff_cb(int status, void *cb_arg)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+
+	if (status) {
+		spdk_jsonrpc_send_error_response_fmt(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+				"OCF could not set sequential cutoff parameters: %d", status);
+	} else {
+		spdk_jsonrpc_send_bool_response(request, true);
+	}
+}
+
+/* Structure to hold the parameters for this RPC method. */
+struct rpc_bdev_ocf_set_seqcutoff {
+	char *name;		/* main vbdev name */
+	char *policy;
+	int32_t threshold;
+	int32_t promotion_count;
+};
+
+static void
+free_rpc_bdev_ocf_set_seqcutoff(struct rpc_bdev_ocf_set_seqcutoff *r)
+{
+	free(r->name);
+	free(r->policy);
+}
+
+/* Structure to decode the input parameters for this RPC method. */
+static const struct spdk_json_object_decoder rpc_bdev_ocf_set_seqcutoff_decoders[] = {
+	{"name", offsetof(struct rpc_bdev_ocf_set_seqcutoff, name),
+			spdk_json_decode_string},
+	{"policy", offsetof(struct rpc_bdev_ocf_set_seqcutoff, policy),
+			spdk_json_decode_string},
+	{"threshold", offsetof(struct rpc_bdev_ocf_set_seqcutoff, threshold),
+			spdk_json_decode_int32},
+	{"promotion_count", offsetof(struct rpc_bdev_ocf_set_seqcutoff, promotion_count),
+			spdk_json_decode_int32},
+};
+
+static void
+rpc_bdev_ocf_set_seqcutoff(struct spdk_jsonrpc_request *request,
+		const struct spdk_json_val *params)
+{
+	struct rpc_bdev_ocf_set_seqcutoff req = {NULL};
+	struct vbdev_ocf *vbdev;
+	int ret;
+
+	ret = spdk_json_decode_object(params, rpc_bdev_ocf_set_seqcutoff_decoders,
+			SPDK_COUNTOF(rpc_bdev_ocf_set_seqcutoff_decoders), &req);
+	if (ret) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+				"Invalid parameters");
+		goto end;
+	}
+
+	vbdev = vbdev_ocf_get_by_name(req.name);
+	if (vbdev == NULL) {
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+				spdk_strerror(ENODEV));
+		goto end;
+	}
+
+	vbdev_ocf_set_seqcutoff(vbdev, req.policy, req.threshold,
+			req.promotion_count, seqcutoff_cb, request);
+
+end:
+	free_rpc_bdev_ocf_set_seqcutoff(&req);
+}
+SPDK_RPC_REGISTER("bdev_ocf_set_seqcutoff", rpc_bdev_ocf_set_seqcutoff, SPDK_RPC_RUNTIME)

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -341,6 +341,23 @@ if __name__ == "__main__":
     p.add_argument('mode', help='OCF cache mode', choices=['wb', 'wt', 'pt', 'wa', 'wi', 'wo'])
     p.set_defaults(func=bdev_ocf_set_cache_mode)
 
+    def bdev_ocf_set_seqcutoff(args):
+        rpc.bdev.bdev_ocf_set_seqcutoff(args.client,
+                                        name=args.name,
+                                        policy=args.policy,
+                                        threshold=args.threshold,
+                                        promotion_count=args.promotion_count)
+    p = subparsers.add_parser('bdev_ocf_set_seqcutoff',
+                              help='Set sequential cutoff parameters on all cores for the given OCF cache device')
+    p.add_argument('name', help='Name of OCF cache bdev')
+    p.add_argument('-p', '--policy', choices=['always', 'full', 'never'], default='none',
+                   help='Sequential cutoff policy')
+    p.add_argument('-t', '--threshold', type=int, default=-1,
+                   help='Activation threshold [KiB]')
+    p.add_argument('-c', '--promotion-count', type=int, default=-1,
+                   help='Stream promotion request count threshold')
+    p.set_defaults(func=bdev_ocf_set_seqcutoff)
+
     def bdev_malloc_create(args):
         num_blocks = (args.total_size * 1024 * 1024) // args.block_size
         print_json(rpc.bdev.bdev_malloc_create(args.client,

--- a/scripts/rpc/bdev.py
+++ b/scripts/rpc/bdev.py
@@ -229,6 +229,25 @@ def bdev_ocf_set_cache_mode(client, name, mode):
     return client.call('bdev_ocf_set_cache_mode', params)
 
 
+def bdev_ocf_set_seqcutoff(client, name, policy, threshold, promotion_count):
+    """Set sequential cutoff parameters on all cores for the given OCF cache device
+
+    Args:
+        name: Name of OCF cache bdev
+        policy: Sequential cutoff policy
+        threshold: Activation threshold [KiB]
+        promotion_count: Stream promotion request count threshold
+    """
+    params = {
+        'name': name,
+        'policy': policy,
+        'threshold': threshold,
+        'promotion_count': promotion_count,
+    }
+
+    return client.call('bdev_ocf_set_seqcutoff', params)
+
+
 @deprecated_alias('construct_malloc_bdev')
 def bdev_malloc_create(client, num_blocks, block_size, name=None, uuid=None):
     """Construct a malloc block device.


### PR DESCRIPTION
Add bdev_ocf_set_seqcutoff RPC method for changing
sequential cutoff policy and parameters.

Signed-off-by: Rafal Stefanowski <rafal.stefanowski@intel.com>